### PR TITLE
Release on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "git-clean"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.2.0"
 authors = ["Matt Casper <matthewvcasper@gmail.com>"]
 
 [dependencies]
-getopts = "*"
+getopts = "0.2"

--- a/README.md
+++ b/README.md
@@ -85,14 +85,11 @@ distribution for your machine.
 This was developed on rust 1.3.0 stable, so if you're having issues with the
 compile/install step, make sure your rust version is >= 1.3.0 stable.
 
-Clone the repo:
-`git clone git@github.com:mcasper/git-clean`
-
-Cd to the installation:
-`cd git-clean`
-
-Run the install script with sudo:
-`sudo ./install.sh`
+With Rust installed, we can now use the Rust package manager, `cargo`, to
+install git-clean:
+```
+cargo install git-clean
+```
 
 Verify that it works!:
 ```


### PR DESCRIPTION
Update the README to reflect new installation process
Bump version to 0.2
Remove wildcard restraint on getopts crate