### PR TITLE
Work with squashed merges.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "git-clean"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-clean"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Matt Casper <matthewvcasper@gmail.com>"]
 license = "MIT"
 description = "A tool for cleaning old git branches."

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,7 +2,7 @@ use std::process::{Command, Stdio, Child, Output};
 use std::io::{Read, Write};
 use std::collections::BTreeSet;
 
-use options::{GitOptions};
+use options::GitOptions;
 use branches::Branches;
 
 pub fn spawn_piped(args: Vec<&str>) -> Child {
@@ -31,9 +31,9 @@ pub fn delete_local_branches(branches: &Branches) -> String {
         xargs.stdin.unwrap().write_all(&branches.string.as_bytes()).unwrap()
     }
 
-    let mut s = String::new();
-    xargs.stdout.unwrap().read_to_string(&mut s).unwrap();
-    s
+    let mut branches_delete_result = String::new();
+    xargs.stdout.unwrap().read_to_string(&mut branches_delete_result).unwrap();
+    branches_delete_result
 }
 
 pub fn delete_remote_branches(branches: &Branches, git_options: &GitOptions) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,8 @@
 
 extern crate getopts;
 
-use std::io;
+use std::{env, io};
 use std::io::{Read, Write};
-use std::env;
 
 use getopts::Options;
 
@@ -93,19 +92,19 @@ fn print_warning(branches: &Branches, del_opt: &DeleteOption) {
 
 fn merged_branches(git_options: &GitOptions) -> Branches {
     let base_branch = &git_options.base_branch;
-    let regex = format!("(\\*{branch}|\\s{branch})", branch = base_branch);
+    let regex = format!("\\*{branch}|\\s{branch}", branch = base_branch);
     let grep = spawn_piped(vec!["grep", "-vE", &regex]);
 
-    let gbranch = run_command(vec!["git", "branch", "--merged", base_branch]);
+    let gbranch = run_command(vec!["git", "branch", "--contains", base_branch]);
 
     {
         grep.stdin.unwrap().write_all(&gbranch.stdout).unwrap();
     }
 
-    let mut s = String::new();
-    grep.stdout.unwrap().read_to_string(&mut s).unwrap();
+    let mut grep_result = String::new();
+    grep.stdout.unwrap().read_to_string(&mut grep_result).unwrap();
 
-    Branches::new(&s)
+    Branches::new(&grep_result)
 }
 
 fn delete_branches(branches: &Branches, options: &DeleteOption, git_options: &GitOptions) -> String {


### PR DESCRIPTION
Github recently released a feature allowing you to squash your merge
(exclude a merge commit and just rebase your branch over master)
directly from the pull request, which makes a currently exiting feature
of Git much more prominent. Searching for branches with `git branch
--contains <base_branch>` rather than `git branch --merged
<base_branch>` should solve the problem.

Is also coupled with a couple stylistic changes (curly braces, names of
variables), and a minor version bump.

@mikeastock This should fix your problem.