### PR TITLE
Integration tests and bug fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rust:
   - stable
   - beta
   - nightly
+before_script:
+  - git config --global user.email "user@example.com"
+  - git config --global user.name "Example User"
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,32 @@ name = "git-clean"
 version = "0.2.2"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "getopts"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,10 @@ homepage = "https://github.com/mcasper/git-clean"
 repository = "https://github.com/mcasper/git-clean"
 
 [dependencies]
-getopts = "0.2"
+getopts = "0.2.14"
+
+[dev-dependencies]
+tempdir = "0.3.4"
+
+[[test]]
+name = "tests"

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ You will need Rust installed to run this tool, so head
 [here](https://www.rust-lang.org/downloads.html) to find the appropriate
 distribution for your machine.
 
-This was developed on rust 1.6.0 stable, so if you're having issues with the
-compile/install step, make sure your rust version is >= 1.6.0 stable.
+This was developed on rust 1.8.0 stable, so if you're having issues with the
+compile/install step, make sure your rust version is >= 1.8.0 stable.
 
 With Rust installed, we can now use the Rust package manager, `cargo`, to
 install git-clean:

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ fn merged_branches(git_options: &GitOptions) -> Branches {
     let regex = format!("\\*{branch}|\\s{branch}", branch = base_branch);
     let grep = spawn_piped(vec!["grep", "-vE", &regex]);
 
-    let gbranch = run_command(vec!["git", "branch", "--contains", base_branch]);
+    let gbranch = run_command(vec!["git", "branch", "--merged"]);
 
     {
         grep.stdin.unwrap().write_all(&gbranch.stdout).unwrap();

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -20,6 +20,27 @@ fn test_git_clean_removes_local_branches() {
 }
 
 #[test]
+fn test_git_clean_works_with_merged_branches() {
+    let project = project("git-clean_squashed_merges").build();
+
+    project.batch_setup_commands(
+        vec![
+            "git checkout -b merged",
+            "touch file2.txt",
+            "git add .",
+            "git commit -am Merged",
+            "git checkout master",
+            "git merge merged",
+        ]
+    );
+
+    let result = project.git_clean_command("-y");
+
+    assert!(result.is_success(), result.failure_message("command to succeed"));
+    assert!(result.stdout().contains("Deleted branch merged"), result.failure_message("command to delete merged"));
+}
+
+#[test]
 fn test_git_clean_works_with_squashed_merges() {
     let project = project("git-clean_squashed_merges").build();
 

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1,0 +1,61 @@
+use support::project;
+
+#[test]
+fn test_git_clean_removes_local_branches() {
+    let project = project("git-clean_removes").build();
+
+    project.setup_command("git branch test1");
+    project.setup_command("git branch test2");
+
+    let verify = project.setup_command("git branch");
+
+    assert!(verify.stdout().contains("test1"), verify.failure_message("test1"));
+    assert!(verify.stdout().contains("test2"), verify.failure_message("test2"));
+
+    let result = project.git_clean_command("-y");
+
+    assert!(result.is_success(), result.failure_message("command to succeed"));
+    assert!(result.stdout().contains("Deleted branch test1"), result.failure_message("command to delete test1"));
+    assert!(result.stdout().contains("Deleted branch test2"), result.failure_message("command to delete test2"));
+}
+
+#[test]
+fn test_git_clean_works_with_squashed_merges() {
+    let project = project("git-clean_squashed_merges").build();
+
+    project.batch_setup_commands(
+        vec![
+            "git checkout -b squashed",
+            "touch file2.txt",
+            "git add .",
+            "git commit -am Squash",
+            "git checkout master",
+            "git merge --ff-only squashed",
+        ]
+    );
+
+    let result = project.git_clean_command("-y");
+
+    assert!(result.is_success(), result.failure_message("command to succeed"));
+    assert!(result.stdout().contains("Deleted branch squashed"), result.failure_message("command to delete squashed"));
+}
+
+#[test]
+fn test_git_clean_does_not_delete_branches_ahead_of_master() {
+    let project = project("git-clean_branch_ahead").build();
+
+    project.batch_setup_commands(
+        vec![
+            "git checkout -b ahead",
+            "touch file2.txt",
+            "git add .",
+            "git commit -am Ahead",
+            "git checkout master",
+        ]
+    );
+
+    let result = project.git_clean_command("-y");
+
+    assert!(result.is_success(), result.failure_message("command to succeed"));
+    assert!(!result.stdout().contains("Deleted branch ahead"), result.failure_message("command not to delete ahead"));
+}

--- a/tests/support.rs
+++ b/tests/support.rs
@@ -1,0 +1,141 @@
+use std::{env, str};
+use std::path::{PathBuf, Path};
+use std::process::{Command, Output};
+use tempdir::TempDir;
+
+pub fn project(name: &str) -> ProjectBuilder {
+    ProjectBuilder::new(name)
+}
+
+pub struct ProjectBuilder {
+    pub name: String,
+}
+
+impl ProjectBuilder {
+    fn new(name: &str) -> Self {
+        ProjectBuilder {
+            name: name.into(),
+        }
+    }
+
+    pub fn build(self) -> Project {
+        let tempdir = TempDir::new(&self.name).unwrap();
+
+        let project = Project {
+            directory: tempdir,
+            name: self.name,
+        };
+
+        project.batch_setup_commands(
+            vec![
+                "git init",
+                "git remote add origin www.example.com",
+                "touch test_file.txt",
+                "git add .",
+                "git commit -am Init",
+            ]
+        );
+
+        project
+    }
+}
+
+pub struct Project {
+    directory: TempDir,
+    pub name: String,
+}
+
+impl Project {
+    pub fn setup_command(&self, command: &str) -> TestCommandResult {
+        let command_pieces = command.split(" ").collect::<Vec<&str>>();
+        let result = TestCommand::new(
+            &self.path(),
+            command_pieces[1..].to_vec(),
+            command_pieces[0]
+            ).run();
+
+        if !result.is_success() {
+            panic!(result.failure_message("setup command to succeed"))
+        }
+
+        result
+    }
+
+    pub fn batch_setup_commands(&self, commands: Vec<&str>) {
+        commands.iter().map(|command| self.setup_command(command)).collect::<Vec<TestCommandResult>>();
+    }
+
+    pub fn git_clean_command(&self, command: &str) -> TestCommandResult {
+        let command_pieces = command.split(" ").collect::<Vec<&str>>();
+        TestCommand::new(&self.path(), command_pieces, path_to_git_clean()).run()
+    }
+
+    fn path(&self) -> PathBuf {
+        self.directory.path().into()
+    }
+}
+
+pub struct TestCommand {
+    pub path: PathBuf,
+    args: Vec<String>,
+    top_level_command: String,
+}
+
+impl TestCommand {
+    fn new<S: Into<String>>(path: &Path, args: Vec<&str>, top_level_command: S) -> Self {
+        let owned_args = args.iter().map(|arg| arg.to_owned().to_owned()).collect::<Vec<String>>();
+
+        TestCommand {
+            path: path.into(),
+            args: owned_args,
+            top_level_command: top_level_command.into(),
+        }
+    }
+
+    pub fn run(&self) -> TestCommandResult {
+        let mut command = Command::new(&self.top_level_command);
+        let output = command
+            .args(&self.args)
+            .current_dir(&self.path)
+            .output()
+            .unwrap();
+
+        TestCommandResult {
+            output: output,
+        }
+    }
+}
+
+pub struct TestCommandResult {
+    output: Output,
+}
+
+impl TestCommandResult {
+    pub fn is_success(&self) -> bool {
+        self.output.status.success()
+    }
+
+     pub fn stdout(&self) -> &str {
+          str::from_utf8(&self.output.stdout).unwrap()
+     }
+
+     pub fn stderr(&self) -> &str {
+          str::from_utf8(&self.output.stderr).unwrap()
+     }
+
+     pub fn failure_message(&self, expectation: &str) -> String {
+         format!("Expected {}, instead found\nstdout: {}\nstderr: {}\n",
+                 expectation,
+                 self.stdout(),
+                 self.stderr(),
+                 )
+     }
+}
+
+fn path_to_git_clean() -> String {
+    env::current_exe().unwrap()
+        .parent().unwrap()
+        .join("git-clean")
+        .to_str().unwrap()
+        .to_owned()
+}

--- a/tests/support.rs
+++ b/tests/support.rs
@@ -29,7 +29,7 @@ impl ProjectBuilder {
         project.batch_setup_commands(
             vec![
                 "git init",
-                "git remote add origin www.example.com",
+                "git remote add origin remote",
                 "touch test_file.txt",
                 "git add .",
                 "git commit -am Init",

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,7 @@
+extern crate tempdir;
+
+// Module full of support functions and structs for integration tests
+mod support;
+
+// Actual integration tests
+mod local;


### PR DESCRIPTION
Our current unit tests don't really give any assurance that git-clean
actually works, just that a few of the outputs remain the same. The only
way to really test that I haven't broken everything is through
integration tests, where we set up a git repo, commit some branches, and
try deleting them. This adds the integration tests framework, and some
of the core tests around deleting functionality, all using local
branches at the moment.

A git remote _can_ be a local folder, so that'll be the next target for
tests.

Recently I swapped us over to using `git branch --contains master`,
which was pretty silly of me - most branches contain master's current
commit, depending on the size of project you're working on. This could
lead to a situation where git-clean would delete branches that are
entirely valid and ahead of master, not quite the desired behavior.

Turns out that all we needed to do was drop the branch argument from
`git branch --merged`, it's already smart enough on its own to handle
squashed merges (as proven now by our integration tests!).