### PR TITLE
ignore a branch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
     opts.optflag("s", "squashes", "check for squashes by finding branches incompatible with master");
     opts.optopt("R", "remote", "changes the git remote used (default is origin)", "REMOTE");
     opts.optopt("b", "branch", "changes the base for merged branches (default is master)", "BRANCH");
+    opts.optmulti("i", "ignore", "ignores given branches", "BRANCH");
     opts.optflag("h", "help", "print this help menu");
     opts.optflag("v", "version", "print the version");
 
@@ -126,7 +127,11 @@ fn merged_branches(git_options: &GitOptions) -> Branches {
 
     let mut local_branches_output = String::new();
     local_branches_filter.stdout.unwrap().read_to_string(&mut local_branches_output).unwrap();
-    let local_branches = local_branches_output.split('\n').map(|b| b.trim().into()).collect::<Vec<String>>();
+
+    let local_branches = local_branches_output.split('\n')
+                                              .map(|b| b.trim().into())
+                                              .filter(|branch| !git_options.ignored_branches.contains(&branch))
+                                              .collect::<Vec<String>>();
 
     let remote_branches_regex = format!("(HEAD|{})", &git_options.base_branch);
     let remote_branches_filter = spawn_piped(&["grep", "-vE", &remote_branches_regex]);

--- a/src/options.rs
+++ b/src/options.rs
@@ -40,6 +40,7 @@ pub struct GitOptions {
     pub remote: String,
     pub base_branch: String,
     pub squashes: bool,
+    pub ignored_branches: Vec<String>,
 }
 
 impl GitOptions {
@@ -52,11 +53,13 @@ impl GitOptions {
             Some(branch) => branch,
             None => "master".to_owned(),
         };
+        let ignored_branches = opts.opt_strs("i");
         let squashes = opts.opt_present("squashes");
 
         GitOptions {
             remote: remote,
             base_branch: base_branch,
+            ignored_branches: ignored_branches,
             squashes: squashes,
         }
     }
@@ -99,6 +102,7 @@ mod test {
         opts.optflag("r", "remotes", "only delete remote branches");
         opts.optopt("R", "", "changes the git remote used (default is origin)", "REMOTE");
         opts.optopt("b", "", "changes the base for merged branches (default is master)", "BRANCH");
+        opts.optmulti("i", "", "ignored branch", "BRANCH");
         opts.optflag("", "squashes", "");
         opts.optflag("h", "help", "print this help menu");
 

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -18,3 +18,22 @@ fn test_git_clean_removes_local_branches() {
     assert!(result.stdout().contains("Deleted branch test1"), result.failure_message("command to delete test1"));
     assert!(result.stdout().contains("Deleted branch test2"), result.failure_message("command to delete test2"));
 }
+
+#[test]
+fn test_git_clean_does_not_remove_ignored_local_branches() {
+    let project = project("git-clean_removes_local").build();
+
+    project.setup_command("git branch test1");
+    project.setup_command("git branch test2");
+
+    let verify = project.setup_command("git branch");
+
+    assert!(verify.stdout().contains("test1"), verify.failure_message("test1"));
+    assert!(verify.stdout().contains("test2"), verify.failure_message("test2"));
+
+    let result = project.git_clean_command("-y -i test2").run();
+
+    assert!(result.is_success(), result.failure_message("command to succeed"));
+    assert!(result.stdout().contains("Deleted branch test1"), result.failure_message("command to delete test1"));
+    assert!(!result.stdout().contains("Deleted branch test2"), result.failure_message("command to delete test2"));
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -37,3 +37,25 @@ fn test_git_clean_does_not_remove_ignored_local_branches() {
     assert!(result.stdout().contains("Deleted branch test1"), result.failure_message("command to delete test1"));
     assert!(!result.stdout().contains("Deleted branch test2"), result.failure_message("command to delete test2"));
 }
+
+#[test]
+fn test_git_clean_does_not_remove_list_of_ignored_local_branches() {
+    let project = project("git-clean_removes_local").build();
+
+    project.setup_command("git branch test1");
+    project.setup_command("git branch test2");
+    project.setup_command("git branch test3");
+
+    let verify = project.setup_command("git branch");
+
+    assert!(verify.stdout().contains("test1"), verify.failure_message("test1"));
+    assert!(verify.stdout().contains("test2"), verify.failure_message("test2"));
+    assert!(verify.stdout().contains("test3"), verify.failure_message("test3"));
+
+    let result = project.git_clean_command("-y -i test1 -i test3").run();
+
+    assert!(result.is_success(), result.failure_message("command to succeed"));
+    assert!(!result.stdout().contains("Deleted branch test1"), result.failure_message("command to delete test1"));
+    assert!(result.stdout().contains("Deleted branch test2"), result.failure_message("command to delete test2"));
+    assert!(!result.stdout().contains("Deleted branch test3"), result.failure_message("command to delete test3"));
+}

--- a/tests/remote.rs
+++ b/tests/remote.rs
@@ -26,6 +26,32 @@ fn test_git_clean_removes_remote_branches() {
     assert!(result.stdout().contains(deleted_branch_output("test2").as_str()), result.failure_message("command to delete test2"));
 }
 
+#[test]
+fn test_git_clean_does_not_remove_ignored_remote_branches() {
+    let project = project("git-clean_removes_remote").build().setup_remote();
+
+    project.batch_setup_commands(
+        &[
+            "git checkout -b test1",
+            "git push origin HEAD",
+            "git checkout -b test2",
+            "git push origin HEAD",
+            "git checkout master",
+        ]
+    );
+
+    let verify = project.setup_command("git branch -r");
+
+    assert!(verify.stdout().contains("test1"), verify.failure_message("test1 to exist in remote"));
+    assert!(verify.stdout().contains("test2"), verify.failure_message("test2 to exist in remote"));
+
+    let result = project.git_clean_command("-y -i test2").run();
+
+    assert!(result.is_success(), result.failure_message("command to succeed"));
+    assert!(result.stdout().contains(deleted_branch_output("test1").as_str()), result.failure_message("command to delete test1"));
+    assert!(!result.stdout().contains(deleted_branch_output("test2").as_str()), result.failure_message("command to delete test2"));
+}
+
 fn deleted_branch_output(branch: &str) -> String {
     format!(" - [deleted]         {}", branch)
 }


### PR DESCRIPTION
in order to implement https://github.com/mcasper/git-clean/issues/24

i think this is far from optimal, but at least it complied, so i'm happy for now 😸 

from what i've seen, i think it would make sense to have a list of ignored branches where the base branch ie. master is in by default.

i would probably not do this through grep, but filter the list of branches after having clean input from git branch or something.