### PR TITLE
Fixed: Support Windows #30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +63,7 @@ name = "git-clean"
 version = "0.6.0"
 dependencies = [
  "clap",
+ "regex",
  "tempdir",
 ]
 
@@ -71,6 +81,12 @@ name = "libc"
 version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "rand"
@@ -108,6 +124,23 @@ checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
 ]
+
+[[package]]
+name = "regex"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ autotests = false
 
 [dependencies]
 clap = "2.33.1"
+regex = "1.6"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/branches.rs
+++ b/src/branches.rs
@@ -1,7 +1,8 @@
 use commands::*;
 use error::Error;
 use options::*;
-use std::io::{stdin, stdout, Read, Write};
+use regex::Regex;
+use std::io::{stdin, stdout, Write};
 
 pub const COLUMN_SPACER_LENGTH: usize = 30;
 
@@ -42,84 +43,63 @@ impl Branches {
         println!("Updating remote {}", options.remote);
         run_command_with_no_output(&["git", "remote", "update", &options.remote, "--prune"]);
 
-        let merged_branches_regex =
-            format!("\\*{branch}|\\s{branch}", branch = &options.base_branch);
-        let merged_branches_filter = spawn_piped(&["grep", "-vE", &merged_branches_regex]);
+        let merged_branches_regex = format!("^\\*?\\s*{}$", options.base_branch);
+        let merged_branches_filter =  Regex::new(&merged_branches_regex).unwrap();
         let merged_branches_cmd = run_command(&["git", "branch", "--merged"]);
+        let merged_branches_output = std::str::from_utf8(&merged_branches_cmd.stdout).unwrap();
 
-        {
-            merged_branches_filter
-                .stdin
-                .unwrap()
-                .write_all(&merged_branches_cmd.stdout)
-                .unwrap();
-        }
+        let merged_branches = merged_branches_output
+            .lines()
+            .fold(Vec::<String>::new(), |mut acc, line| {
+                if !merged_branches_filter.is_match(line) {
+                    acc.push(line.trim().to_string());
+                }
+                acc
+            });
 
-        let mut merged_branches_output = String::new();
-        merged_branches_filter
-            .stdout
-            .unwrap()
-            .read_to_string(&mut merged_branches_output)
-            .unwrap();
-        let mut merged_branches = merged_branches_output.split('\n').map(|b| b.trim().into());
-
-        let local_branches_regex =
-            format!("\\*{branch}|\\s{branch}", branch = &options.base_branch);
-        let local_branches_filter = spawn_piped(&["grep", "-vE", &local_branches_regex]);
+        let local_branches_regex = format!("^\\*?\\s*{}$", options.base_branch);
+        let local_branches_filter = Regex::new(&local_branches_regex).unwrap();
         let local_branches_cmd = run_command(&["git", "branch"]);
-
-        {
-            local_branches_filter
-                .stdin
-                .unwrap()
-                .write_all(&local_branches_cmd.stdout)
-                .unwrap();
-        }
-
-        let mut local_branches_output = String::new();
-        local_branches_filter
-            .stdout
-            .unwrap()
-            .read_to_string(&mut local_branches_output)
-            .unwrap();
+        let local_branches_output = std::str::from_utf8(&local_branches_cmd.stdout).unwrap();
 
         let local_branches = local_branches_output
-            .split('\n')
-            .map(|b| b.trim().into())
+            .lines()
+            .fold(Vec::<String>::new(), |mut acc, line| {
+                if !local_branches_filter.is_match(line) {
+                    acc.push(line.trim().to_string());
+                }
+                acc
+            })
+            .iter()
             .filter(|branch| !options.ignored_branches.contains(branch))
+            .cloned()
             .collect::<Vec<String>>();
 
-        let remote_branches_regex = format!("(HEAD|{})", &options.base_branch);
-        let remote_branches_filter = spawn_piped(&["grep", "-vE", &remote_branches_regex]);
+        let remote_branches_regex = format!("\\b(HEAD|{})\\b", &options.base_branch);
+        let remote_branches_filter = Regex::new(&remote_branches_regex).unwrap();
         let remote_branches_cmd = run_command(&["git", "branch", "-r"]);
+        let remote_branches_output = std::str::from_utf8(&remote_branches_cmd.stdout).unwrap();
 
-        {
-            remote_branches_filter
-                .stdin
-                .unwrap()
-                .write_all(&remote_branches_cmd.stdout)
-                .unwrap();
-        }
-
-        let mut remote_branches_output = String::new();
-        remote_branches_filter
-            .stdout
-            .unwrap()
-            .read_to_string(&mut remote_branches_output)
-            .unwrap();
-        let mut remote_branches = remote_branches_output.split('\n').map(|b| b.trim().into());
+        let remote_branches = remote_branches_output
+            .lines()
+            .fold(Vec::<String>::new(), |mut acc, line| {
+                if !remote_branches_filter.is_match(line) {
+                    acc.push(line.trim().to_string());
+                }
+                acc
+            });
 
         for branch in local_branches {
             // First check if the local branch doesn't exist in the remote, it's the cheapest and easiest
             // way to determine if we want to suggest to delete it.
-            if !remote_branches.any(|b: String| b == format!("{}/{}", &options.remote, branch)) {
+            if !remote_branches.iter().any(|b: &String| *b == format!("{}/{}", &options.remote, branch)) {
                 branches.push(branch.to_owned());
                 continue;
             }
 
             // If it does exist in the remote, check to see if it's listed in git branches --merged. If
             // it is, that means it wasn't merged using Github squashes, and we can suggest it.
-            if merged_branches.any(|b: String| b == branch) {
+            if merged_branches.iter().any(|b: &String| *b == branch) {
                 branches.push(branch.to_owned());
                 continue;
             }

--- a/src/branches.rs
+++ b/src/branches.rs
@@ -33,7 +33,7 @@ impl Branches {
         stdin().read_line(&mut input)?;
 
         match input.to_lowercase().as_ref() {
-            "y\n" | "yes\n" | "\n" => Ok(()),
+            "y\n" | "y\r\n" | "yes\n" | "yes\r\n" | "\n" | "\r\n" => Ok(()),
             _ => Err(Error::ExitEarly),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 extern crate clap;
 
+extern crate regex;
+
 pub mod cli;
 
 use clap::ArgMatches;

--- a/tests/deletion.rs
+++ b/tests/deletion.rs
@@ -1,12 +1,25 @@
 use support::project;
 
+macro_rules! touch_command {
+    ($project:ident, $file_name:literal) => {
+        if cfg!(windows) {
+            format!("cmd /c copy nul {}\\{}", $project.path().display(), $file_name)
+        } else {
+            format!("touch {}", $file_name)
+        }
+    };
+}
+
+
 #[test]
 fn test_git_clean_works_with_merged_branches() {
     let project = project("git-clean_squashed_merges").build().setup_remote();
 
+    let touch_command = touch_command!(project, "file2.txt");
+
     project.batch_setup_commands(&[
         "git checkout -b merged",
-        "touch file2.txt",
+        &touch_command,
         "git add .",
         "git commit -am Merged",
         "git checkout main",
@@ -31,9 +44,11 @@ fn test_git_clean_works_with_merged_branches() {
 fn test_git_clean_works_with_squashed_merges() {
     let project = project("git-clean_squashed_merges").build().setup_remote();
 
+    let touch_command = touch_command!(project, "file2.txt");
+
     project.batch_setup_commands(&[
         "git checkout -b squashed",
-        "touch file2.txt",
+        &touch_command,
         "git add .",
         "git commit -am Squash",
         "git checkout main",
@@ -58,9 +73,11 @@ fn test_git_clean_works_with_squashed_merges() {
 fn test_git_clean_does_not_delete_branches_ahead_of_main() {
     let project = project("git-clean_branch_ahead").build().setup_remote();
 
+    let touch_command = touch_command!(project, "file2.txt");
+
     project.batch_setup_commands(&[
         "git checkout -b ahead",
-        "touch file2.txt",
+        &touch_command,
         "git add .",
         "git commit -am Ahead",
         "git push origin HEAD",
@@ -85,6 +102,9 @@ fn test_git_clean_does_not_delete_branches_ahead_of_main() {
 fn test_git_clean_works_with_squashes_with_flag() {
     let project = project("git-clean_github_squashes").build().setup_remote();
 
+    let touch_squash_command = touch_command!(project, "squash.txt");
+    let touch_new_command = touch_command!(project, "new.txt");
+
     // Github squashes function basically like a normal squashed merge, it creates an entirely new
     // commit in which all your changes live. The biggest challenge of this is that your local
     // branch doesn't have any knowledge of this new commit. So if main gets ahead of your local
@@ -92,15 +112,15 @@ fn test_git_clean_works_with_squashes_with_flag() {
     // this condition.
     project.batch_setup_commands(&[
         "git checkout -b github_squash",
-        "touch squash.txt",
+        &touch_squash_command,
         "git add .",
         "git commit -am Commit",
         "git push origin HEAD",
         "git checkout main",
-        "touch squash.txt",
+        &touch_squash_command,
         "git add .",
         "git commit -am Squash",
-        "touch new.txt",
+        &touch_new_command,
         "git add .",
         "git commit -am Other",
         "git push origin HEAD",
@@ -133,6 +153,9 @@ fn test_git_clean_ignores_squashes_without_flag() {
         .build()
         .setup_remote();
 
+    let touch_squash_command = touch_command!(project, "squash.txt");
+    let touch_new_command = touch_command!(project, "new.txt");
+
     // Github squashes function basically like a normal squashed merge, it creates an entirely new
     // commit in which all your changes live. The biggest challenge of this is that your local
     // branch doesn't have any knowledge of this new commit. So if main gets ahead of your local
@@ -140,15 +163,15 @@ fn test_git_clean_ignores_squashes_without_flag() {
     // this condition.
     project.batch_setup_commands(&[
         "git checkout -b github_squash",
-        "touch squash.txt",
+        &touch_squash_command,
         "git add .",
         "git commit -am Commit",
         "git push origin HEAD",
         "git checkout main",
-        "touch squash.txt",
+        &touch_squash_command,
         "git add .",
         "git commit -am Squash",
-        "touch new.txt",
+        &touch_new_command,
         "git add .",
         "git commit -am Other",
         "git push origin HEAD",


### PR DESCRIPTION
* replaced `touch` in windows context with `copy nul file.txt`
* replaced `grep` with `regex::Regex`
* replaced `xargs` by giving multiple branch names to `git branch -d/-D'
* tested on Windows and WSL Ubuntu