### PR TITLE
by default, do not delete local-only branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,8 @@ USAGE:
     git-clean [FLAGS] [OPTIONS]
 
 FLAGS:
-    -d, --delete_unpushed_branches    delete any local branch that is not present on the
-                                      remote. Enable this if you consider that such
-                                      branches have been merged.
+    -d, --delete_unpushed_branches    delete any local branch that is not present on the remote. Use this to speed up
+                                      the checks if such branches should always be considered as merged
     -h, --help                        Prints help information
     -l, --locals                      only delete local branches
     -r, --remotes                     only delete remote branches

--- a/README.md
+++ b/README.md
@@ -104,18 +104,24 @@ brew install git-clean
 Verify that it works!:
 ```shell
 $ git-clean -h
-Usage: git-clean [options]
+USAGE:
+    git-clean [FLAGS] [OPTIONS]
 
-Options:
-    -l, --locals        only delete local branches
-    -r, --remotes       only delete remote branches
-    -y, --yes           skip the check for deleting branches
-    -s, --squashes      check for squashes by finding branches incompatible with main
-    -R, --remote REMOTE changes the git remote used (default is origin)
-    -b, --branch BRANCH changes the base for merged branches (default is
-                        main)
-    -h, --help          print this help menu
-    -v, --version       print the version
+FLAGS:
+    -d, --delete_unpushed_branches    delete any local branch that is not present on the
+                                      remote. Enable this if you consider that such
+                                      branches have been merged.
+    -h, --help                        Prints help information
+    -l, --locals                      only delete local branches
+    -r, --remotes                     only delete remote branches
+    -s, --squashes                    check for squashes by finding branches incompatible with main
+    -V, --version                     Prints version information
+    -y, --yes                         skip the check for deleting branches
+
+OPTIONS:
+    -b, --branch <branch>       changes the base for merged branches (default is main)
+    -i, --ignore <ignore>...    ignore given branches
+    -R, --remote <remote>       changes the git remote used (default is origin)
 ```
 
 # Updating

--- a/src/branches.rs
+++ b/src/branches.rs
@@ -92,7 +92,7 @@ impl Branches {
         for branch in local_branches {
             // First check if the local branch doesn't exist in the remote, it's the cheapest and easiest
             // way to determine if we want to suggest to delete it.
-            if !remote_branches.iter().any(|b: &String| *b == format!("{}/{}", &options.remote, branch)) {
+            if options.delete_unpushed_branches && !remote_branches.iter().any(|b: &String| *b == format!("{}/{}", &options.remote, branch)) {
                 branches.push(branch.to_owned());
                 continue;
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,6 +36,13 @@ pub fn build_cli() -> App<'static, 'static> {
                 .takes_value(false),
         )
         .arg(
+            Arg::with_name("delete_unpushed_branches")
+                .short("d")
+                .long("delete_unpushed_branches")
+                .help("delete any local branch that is not present on the remote. Enable this if you consider that such branches have been merged.")
+                .takes_value(false),
+        )
+        .arg(
             Arg::with_name("remote")
                 .short("R")
                 .long("remote")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,7 +39,7 @@ pub fn build_cli() -> App<'static, 'static> {
             Arg::with_name("delete_unpushed_branches")
                 .short("d")
                 .long("delete_unpushed_branches")
-                .help("delete any local branch that is not present on the remote. Enable this if you consider that such branches have been merged.")
+                .help("delete any local branch that is not present on the remote. Use this to speed up the checks if such branches should always be considered as merged")
                 .takes_value(false),
         )
         .arg(

--- a/src/options.rs
+++ b/src/options.rs
@@ -40,6 +40,7 @@ pub struct Options {
     pub remote: String,
     pub base_branch: String,
     pub squashes: bool,
+    pub delete_unpushed_branches: bool,
     pub ignored_branches: Vec<String>,
     pub delete_mode: DeleteMode,
 }
@@ -56,6 +57,7 @@ impl Options {
             base_branch: opts.value_of("branch").unwrap_or(DEFAULT_BRANCH).into(),
             ignored_branches: ignored,
             squashes: opts.is_present("squashes"),
+            delete_unpushed_branches: opts.is_present("delete_unpushed_branches"),
             delete_mode: DeleteMode::new(opts),
         }
     }
@@ -169,10 +171,12 @@ mod test {
         assert_eq!("main".to_owned(), git_options.base_branch);
         assert_eq!("upstream".to_owned(), git_options.remote);
         assert!(!git_options.squashes);
+        assert!(!git_options.delete_unpushed_branches);
 
-        let matches = parse_args(vec!["git-clean", "-R", "upstream", "--squashes"]);
+        let matches = parse_args(vec!["git-clean", "-R", "upstream", "--squashes", "--delete_unpushed_branches"]);
         let git_options = Options::new(&matches);
 
         assert!(git_options.squashes);
+        assert!(git_options.delete_unpushed_branches);
     }
 }


### PR DESCRIPTION
This is to fix: https://github.com/mcasper/git-clean/issues/32

The PR introduces a `--delete_unpushed_branches` flag (or `-d`), that, when enabled, deletes any branch that is not found on the remote. The option can be enabled for faster checks, if the user considers that there's no need to check the commits of such branches.

For safety, the option is disabled by default.

This is the first time I write some Rust, so probably it's a bit dirty. Let me know your improvement suggestions :)